### PR TITLE
need to `npm install` before running the js files

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -15,6 +15,11 @@ rm -rf $DIR/../{nsolid-node,nsolid-console,nsolid-proxy}
 echo "Generating image file..."
 $DIR/gen-images.sh > $DIR/../templates/images.js
 
+echo "Running npm install..."
+cd $DIR
+npm install
+cd ..
+
 echo "Generating Dockerfiles..."
 $DIR/gen-dockerfiles.js
 


### PR DESCRIPTION
Also the `dante` invocation at the end fails.  No idea what that is.  Not available on my mac.
