### PR TITLE
Add N|Solid Carbon Docker Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,33 +21,33 @@ If you are looking for documentation on how to use these images, checkout our th
 #### Alpine
 
 ```bash
-NSOLID_VERSION=2.3.0 make alpine
+NSOLID_VERSION=2.3.1 make alpine
 ```
 
 #### Debian / Ubuntu
 
 ```bash
-NSOLID_VERSION=2.3.0 make build 
+NSOLID_VERSION=2.3.1 make build
 ```
 
 ### Publishing Images
 
 ```bash
-DOCKER_REGISTRY=username NSOLID_VERSION=2.3.0 make publish
+DOCKER_REGISTRY=username NSOLID_VERSION=2.3.1 make publish
 ```
 
 #### Alpine
 
 ```bash
-DOCKER_REGISTRY=username NSOLID_VERSION=2.3.0 make publish-alpine
+DOCKER_REGISTRY=username NSOLID_VERSION=2.3.1 make publish-alpine
 ```
 
 
 ### Cleaning up
 
 ```bash
-NSOLID_VERSION=2.3.0 make clean # removes download directories `nsolid-bundle-*`
-NSOLID_VERSION=2.3.0 make cleanall # runs `make clean` and removes all docker images with label=nodesource=nsolid
+NSOLID_VERSION=2.3.1 make clean # removes download directories `nsolid-bundle-*`
+NSOLID_VERSION=2.3.1 make cleanall # runs `make clean` and removes all docker images with label=nodesource=nsolid
 ```
 
 # Contributing

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,11 +2,11 @@
 
 filepath="./dockerfiles"
 
-declare -a versions=("argon" "boron")
+declare -a versions=("argon" "boron" "carbon")
 declare -a images=("nsolid" "nsolid-console" "nsolid-storage" "nsolid-cli")
 
-if [ "$BUILD_ALPINE" == "1" ]; then 
-  filepath="$filepath/alpine" 
+if [ "$BUILD_ALPINE" == "1" ]; then
+  filepath="$filepath/alpine"
   declare -a versions=("boron")
 fi
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -ex
 
-declare -a versions=("argon" "boron")
+declare -a versions=("argon" "boron" "carbon")
 declare -a images=("nsolid" "nsolid-console" "nsolid-storage" "nsolid-cli")
 
 latest=${NSOLID_LTS_LATEST:-'boron'}
 registry=${DOCKER_REGISTRY:-'nodesource'}
 release=${NSOLID_VERSION}
 
-if [ "$BUILD_ALPINE" == "1" ]; then 
+if [ "$BUILD_ALPINE" == "1" ]; then
   declare -a versions=("boron-alpine")
 fi
 
@@ -17,7 +17,7 @@ do
   do
     docker tag nodesource/$img:$lts $registry/$img:$lts-$release
     docker push $registry/$img:$lts-$release
-    
+
     docker tag nodesource/$img:$lts $registry/$img:$lts-latest
     docker push $registry/$img:$lts-latest
 
@@ -26,7 +26,7 @@ do
       docker push $registry/$img:latest
     fi
 
-    if [ "$BUILD_ALPINE" == "1" ]; then 
+    if [ "$BUILD_ALPINE" == "1" ]; then
       docker tag nodesource/$img:$lts $registry/$img:alpine
       docker push $registry/$img:alpine
     fi


### PR DESCRIPTION
PR to add Node 8 support to our Docker Image collection.

This will add a nsolid-carbon image to our fleet of nsolid docker images.