### PR TITLE
Update non-existent tag boron to boron-latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   storage:
-    image: nodesource/nsolid-storage:boron
+    image: nodesource/nsolid-storage:boron-latest
     container_name: nsolid.storage
     ports:
       - 4000:4000
@@ -11,7 +11,7 @@ services:
     environment:
       - NODE_DEBUG=nsolid
   console:
-    image: nodesource/nsolid-console:boron
+    image: nodesource/nsolid-console:boron-latest
     container_name: nsolid.console
     environment:
       - NODE_DEBUG=nsolid
@@ -21,7 +21,7 @@ services:
     ports:
       - 6753:6753
   # app:
-  #   image: nodesource/nsolid:boron
+  #   image: nodesource/nsolid:boron-latest
   #   environment:
   #     - NODE_DEBUG=nsolid
   #     - NSOLID_APPNAME=in_docker

--- a/docker-hub/nsolid-cli.md
+++ b/docker-hub/nsolid-cli.md
@@ -31,7 +31,7 @@ For convenience, we provide the following docker-compose file as an example to g
 version: "2"
 services:
   storage:
-    image: nodesource/nsolid-storage:boron
+    image: nodesource/nsolid-storage:boron-latest
     container_name: nsolid.storage
     ports:
       - 4000:4000
@@ -41,7 +41,7 @@ services:
     environment:
       - NODE_DEBUG=nsolid
   console:
-    image: nodesource/nsolid-console:boron
+    image: nodesource/nsolid-console:boron-latest
     container_name: nsolid.console
     environment:
       - NODE_DEBUG=nsolid
@@ -51,7 +51,7 @@ services:
     ports:
       - 6753:6753
   # app:
-  #   image: nodesource/nsolid:boron
+  #   image: nodesource/nsolid:boron-latest
   #   environment:
   #     - NODE_DEBUG=nsolid
   #     - NSOLID_APPNAME=in_docker

--- a/docker-hub/nsolid-console.md
+++ b/docker-hub/nsolid-console.md
@@ -31,7 +31,7 @@ For convenience, we provide the following docker-compose file as an example to g
 version: "2"
 services:
   storage:
-    image: nodesource/nsolid-storage:boron
+    image: nodesource/nsolid-storage:boron-latest
     container_name: nsolid.storage
     ports:
       - 4000:4000
@@ -41,7 +41,7 @@ services:
     environment:
       - NODE_DEBUG=nsolid
   console:
-    image: nodesource/nsolid-console:boron
+    image: nodesource/nsolid-console:boron-latest
     container_name: nsolid.console
     environment:
       - NODE_DEBUG=nsolid
@@ -51,7 +51,7 @@ services:
     ports:
       - 6753:6753
   # app:
-  #   image: nodesource/nsolid:boron
+  #   image: nodesource/nsolid:boron-latest
   #   environment:
   #     - NODE_DEBUG=nsolid
   #     - NSOLID_APPNAME=in_docker

--- a/docker-hub/nsolid-storage.md
+++ b/docker-hub/nsolid-storage.md
@@ -31,7 +31,7 @@ For convenience, we provide the following docker-compose file as an example to g
 version: "2"
 services:
   storage:
-    image: nodesource/nsolid-storage:boron
+    image: nodesource/nsolid-storage:boron-latest
     container_name: nsolid.storage
     ports:
       - 4000:4000
@@ -41,7 +41,7 @@ services:
     environment:
       - NODE_DEBUG=nsolid
   console:
-    image: nodesource/nsolid-console:boron
+    image: nodesource/nsolid-console:boron-latest
     container_name: nsolid.console
     environment:
       - NODE_DEBUG=nsolid
@@ -51,7 +51,7 @@ services:
     ports:
       - 6753:6753
   # app:
-  #   image: nodesource/nsolid:boron
+  #   image: nodesource/nsolid:boron-latest
   #   environment:
   #     - NODE_DEBUG=nsolid
   #     - NSOLID_APPNAME=in_docker

--- a/docker-hub/nsolid.md
+++ b/docker-hub/nsolid.md
@@ -31,7 +31,7 @@ For convenience, we provide the following docker-compose file as an example to g
 version: "2"
 services:
   storage:
-    image: nodesource/nsolid-storage:boron
+    image: nodesource/nsolid-storage:boron-latest
     container_name: nsolid.storage
     ports:
       - 4000:4000
@@ -41,7 +41,7 @@ services:
     environment:
       - NODE_DEBUG=nsolid
   console:
-    image: nodesource/nsolid-console:boron
+    image: nodesource/nsolid-console:boron-latest
     container_name: nsolid.console
     environment:
       - NODE_DEBUG=nsolid
@@ -51,7 +51,7 @@ services:
     ports:
       - 6753:6753
   # app:
-  #   image: nodesource/nsolid:boron
+  #   image: nodesource/nsolid:boron-latest
   #   environment:
   #     - NODE_DEBUG=nsolid
   #     - NSOLID_APPNAME=in_docker


### PR DESCRIPTION
I was trying out the provided sample docker-compose file and noticed the tag `boron` for each image no longer seems to exist. Updated to `boron-latest`.