### PR TITLE
Remove Boron from Docker builds due to EOL

### DIFF
--- a/docker-hub/nsolid-storage.md
+++ b/docker-hub/nsolid-storage.md
@@ -35,7 +35,7 @@ For convenience, we provide the following docker-compose file as an example to g
 version: "2"
 services:
   storage:
-    image: nodesource/nsolid-storage:boron-latest
+    image: nodesource/nsolid-storage:carbon-latest
     container_name: nsolid.storage
     ports:
       - 4000:4000
@@ -45,7 +45,7 @@ services:
     environment:
       - NODE_DEBUG=nsolid
   console:
-    image: nodesource/nsolid-console:boron-latest
+    image: nodesource/nsolid-console:carbon-latest
     container_name: nsolid.console
     environment:
       - NODE_DEBUG=nsolid
@@ -55,7 +55,7 @@ services:
     ports:
       - 6753:6753
   # app:
-  #   image: nodesource/nsolid:boron-latest
+  #   image: nodesource/nsolid:carbon-latest
   #   environment:
   #     - NODE_DEBUG=nsolid
   #     - NSOLID_APPNAME=in_docker

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,7 +2,7 @@
 
 filepath="./dockerfiles"
 
-declare -a versions=("boron" "carbon" "dubnium")
+declare -a versions=("carbon" "dubnium")
 declare -a images=("nsolid" "nsolid-console" "nsolid-storage" "nsolid-cli")
 
 if [[ ${NSOLID_VERSION} =~ ^3\.(.*)\.(.*) ]]; then
@@ -13,7 +13,7 @@ fi
 
 if [ "$BUILD_ALPINE" == "1" ]; then
   filepath="$filepath/alpine"
-  declare -a versions=("boron" "carbon" "dubnium")
+  declare -a versions=("carbon" "dubnium")
 fi
 
 for lts in "${versions[@]}"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-declare -a versions=("boron" "carbon" "dubnium")
+declare -a versions=("carbon" "dubnium")
 declare -a images=("nsolid" "nsolid-console" "nsolid-storage" "nsolid-cli")
 
 latest=${NSOLID_LTS_LATEST:-'dubnium'}
@@ -8,7 +8,7 @@ registry=${DOCKER_REGISTRY:-'nodesource'}
 release=${NSOLID_VERSION}
 
 if [ "$BUILD_ALPINE" == "1" ]; then
-  declare -a versions=("boron-alpine" "carbon-alpine" "dubnium-alpine")
+  declare -a versions=("carbon-alpine" "dubnium-alpine")
 fi
 
 if [[ ${NSOLID_VERSION} =~ ^3\.(.*)\.(.*) ]]; then


### PR DESCRIPTION
Node.js 6 is now EOL and shouldn't be used anymore.