### PR TITLE
closes: #34 trusty -> bionic for nsolid docker

### DIFF
--- a/dockerfiles/nsolid.dockerfile
+++ b/dockerfiles/nsolid.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:bionic
 MAINTAINER NodeSource <https://nodesource.com/>
 
 ARG NODEJS_LTS=dubnium


### PR DESCRIPTION
Build testing at https://us-west-2.console.aws.amazon.com/codesuite/codebuild/projects/nsolid-docker-build/build/nsolid-docker-build%3A0c7bd8b8-0f34-4339-92ad-6d8f738d1078/log?region=us-west-2
