### PR TITLE
Update to alpine 3.10

### DIFF
--- a/dockerfiles/alpine/nsolid-cli.dockerfile
+++ b/dockerfiles/alpine/nsolid-cli.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.10
 MAINTAINER NodeSource <https://nodesource.com/>
 
 ARG NODEJS_LTS=erbium

--- a/dockerfiles/alpine/nsolid-console-3.dockerfile
+++ b/dockerfiles/alpine/nsolid-console-3.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.10
 MAINTAINER NodeSource <https://nodesource.com/>
 
 ARG NODEJS_LTS=erbium

--- a/dockerfiles/alpine/nsolid-console.dockerfile
+++ b/dockerfiles/alpine/nsolid-console.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.10
 MAINTAINER NodeSource <https://nodesource.com/>
 
 ARG NODEJS_LTS=erbium

--- a/dockerfiles/alpine/nsolid-storage.dockerfile
+++ b/dockerfiles/alpine/nsolid-storage.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.10
 MAINTAINER NodeSource <https://nodesource.com/>
 
 ARG NODEJS_LTS=erbium

--- a/dockerfiles/alpine/nsolid.dockerfile
+++ b/dockerfiles/alpine/nsolid.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.10
 MAINTAINER NodeSource <https://nodesource.com/>
 
 ARG NODEJS_LTS=erbium


### PR DESCRIPTION
Update alpine to latest (3.10) as 3.5 is getting fairly old (3.5.3 released 2018-09-11 https://git.alpinelinux.org/aports/commit/?h=3.5-stable&id=c93942e1ed93cd55bf8235955d4bb397ddda5a50).

Fixes https://github.com/nodesource/docker-nsolid/issues/32